### PR TITLE
Update Installation.md

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -68,7 +68,7 @@ If you wish to use the update manager feature of moonraker for KlipperScreen, ad
 type: git_repo
 path: ~/KlipperScreen
 origin: https://github.com/KlipperScreen/KlipperScreen.git
-virtualenv: ~/.KlipperScreen-env/bin/python
+virtualenv: ~/.KlipperScreen-env
 requirements: scripts/KlipperScreen-requirements.txt
 system_dependencies: scripts/system-dependencies.json
 managed_services: KlipperScreen


### PR DESCRIPTION
Fix changes from env to virtualenv.

`env` uses `~/.KlipperScreen-env/bin/python` but `virtualenv` just needs `~/.KlipperScreen-env`

see https://github.com/Arksine/moonraker/blob/master/docs/configuration.md#update_manager
```
virtualenv:
#   ...
#   Moonraker's default virtualenv is located at ~/moonraker-env.
#   ...
env:
#   ...
#   Moonraker's venv is located at ~/moonraker-env/bin/python.
#   ...
```
